### PR TITLE
Remove meta refresh tag from index.html

### DIFF
--- a/docs/clock02/index.html
+++ b/docs/clock02/index.html
@@ -9,7 +9,6 @@
 	<meta http-equiv="Expires" content="0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="referrer" content="no-referrer" />
-	<meta http-equiv="refresh" content="300">
 	<link rel="stylesheet" type="text/css" href="/lib/master.css?t=0" />
 	<script src="/lib/master.js"></script>
     <link rel="stylesheet" href="css-var-declare.css">


### PR DESCRIPTION
Removed the meta refresh tag to prevent automatic page refresh.